### PR TITLE
feat: assume HTTP when multiaddr ends with /tcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,17 @@ const toUri = require('multiaddr-to-uri')
 
 console.log(toUri('/dnsaddr/protocol.ai/https'))
 // -> https://protocol.ai
+
+console.log(toUri('/ip4/127.0.0.1/tcp/8080'))
+// -> http://127.0.0.1:8080
+
+console.log(toUri('/ip4/127.0.0.1/tcp/8080', { assumeHttp: false }))
+// -> tcp://127.0.0.1:8080
 ```
 
 Note:
 
+* Assumes HTTP by default. Pass `assumeHttp: false` to disable this behavior.
 * Might be lossy - e.g. a DNSv6 multiaddr
 * Can throw if the passed multiaddr:
     * is not a valid multiaddr

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ console.log(toUri('/ip4/127.0.0.1/tcp/8080', { assumeHttp: false }))
 
 Note:
 
-* Assumes HTTP by default. Pass `assumeHttp: false` to disable this behavior.
+* When `/tcp` is the last (terminating) protocol HTTP is assumed by default (implicit `assumeHttp: true`)
+  * this means produced URIs will start with `http://` instead of `tcp://`
+  * passing `{ assumeHttp: false }` disables this behavior
 * Might be lossy - e.g. a DNSv6 multiaddr
 * Can throw if the passed multiaddr:
     * is not a valid multiaddr

--- a/test.js
+++ b/test.js
@@ -7,19 +7,14 @@ test('should convert multiaddr to URI', (t) => {
     ['/ip4/127.0.0.1/http', 'http://127.0.0.1'],
     ['/ip6/fc00::', 'fc00::'],
     ['/ip6/fc00::/http', 'http://[fc00::]'],
-    ['/ip4/0.0.7.6/tcp/1234', 'tcp://0.0.7.6:1234'],
     ['/ip4/0.0.7.6/tcp/1234/http', 'http://0.0.7.6:1234'],
     ['/ip4/0.0.7.6/tcp/1234/https', 'https://0.0.7.6:1234'],
-    ['/ip6/::/tcp/0', 'tcp://[::]:0'],
     ['/ip4/0.0.7.6/udp/1234', 'udp://0.0.7.6:1234'],
     ['/ip6/::/udp/0', 'udp://[::]:0'],
     ['/dnsaddr/ipfs.io', 'ipfs.io'],
     ['/dns4/ipfs.io', 'ipfs.io'],
     ['/dns4/libp2p.io', 'libp2p.io'],
     ['/dns6/protocol.ai', 'protocol.ai'],
-    ['/dns4/protocol.ai/tcp/80', 'tcp://protocol.ai:80'],
-    ['/dns6/protocol.ai/tcp/80', 'tcp://protocol.ai:80'],
-    ['/dnsaddr/protocol.ai/tcp/80', 'tcp://protocol.ai:80'],
     ['/dnsaddr/protocol.ai/tcp/80/http', 'http://protocol.ai:80'],
     ['/dnsaddr/protocol.ai/tcp/80/https', 'https://protocol.ai:80'],
     ['/dnsaddr/ipfs.io/ws', 'ws://ipfs.io'],
@@ -81,6 +76,40 @@ test('should convert multiaddr to URI', (t) => {
   ]
 
   data.forEach(d => t.is(toUri(d[0]), d[1]))
+})
+
+test('should convert multiaddr to http(s):// URI when implicit { assumeHttp: true }', (t) => {
+  const data = [
+    ['/ip4/0.0.7.6/tcp/1234', 'http://0.0.7.6:1234'],
+    ['/ip6/::/tcp/0', 'http://[::]:0'],
+    ['/dns4/protocol.ai/tcp/80', 'http://protocol.ai'],
+    ['/dns6/protocol.ai/tcp/80', 'http://protocol.ai'],
+    ['/dns4/protocol.ai/tcp/8080', 'http://protocol.ai:8080'],
+    ['/dns6/protocol.ai/tcp/8080', 'http://protocol.ai:8080'],
+    ['/dns4/protocol.ai/tcp/443', 'https://protocol.ai'],
+    ['/dns6/protocol.ai/tcp/443', 'https://protocol.ai'],
+    ['/dnsaddr/protocol.ai/tcp/80', 'http://protocol.ai'],
+    ['/dnsaddr/protocol.ai/tcp/443', 'https://protocol.ai'],
+    ['/dnsaddr/protocol.ai/tcp/8080', 'http://protocol.ai:8080']
+  ]
+  data.forEach(d => t.is(toUri(d[0]), d[1]))
+})
+
+test('should convert multiaddr to tcp:// URI when explicit { assumeHttp: false }', (t) => {
+  const data = [
+    ['/ip4/0.0.7.6/tcp/1234', 'tcp://0.0.7.6:1234'],
+    ['/ip6/::/tcp/0', 'tcp://[::]:0'],
+    ['/dns4/protocol.ai/tcp/80', 'tcp://protocol.ai:80'],
+    ['/dns6/protocol.ai/tcp/80', 'tcp://protocol.ai:80'],
+    ['/dns4/protocol.ai/tcp/8080', 'tcp://protocol.ai:8080'],
+    ['/dns6/protocol.ai/tcp/8080', 'tcp://protocol.ai:8080'],
+    ['/dns4/protocol.ai/tcp/443', 'tcp://protocol.ai:443'],
+    ['/dns6/protocol.ai/tcp/443', 'tcp://protocol.ai:443'],
+    ['/dnsaddr/protocol.ai/tcp/80', 'tcp://protocol.ai:80'],
+    ['/dnsaddr/protocol.ai/tcp/443', 'tcp://protocol.ai:443'],
+    ['/dnsaddr/protocol.ai/tcp/8080', 'tcp://protocol.ai:8080']
+  ]
+  data.forEach(d => t.is(toUri(d[0], { assumeHttp: false }), d[1]))
 })
 
 test('should throw for unsupported protocol', (t) => {


### PR DESCRIPTION
This PR:

- makes multiaddrs ending with `/tcp/8080` default to HTTP URI
unless an explicit `assumeHttp: false` flag is passed.
- skips default ports for HTTP and HTTPS, producing prettier URLs and matching what README already says :^)
- adds more tests for HTTP and HTTPS

Motivation: https://github.com/ipfs/js-ipfs/pull/2358#issuecomment-522967758
