### PR TITLE
fix!: remove deprecated transports and do not automatically append peer ids

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,14 +109,14 @@ const interpreters: Record<string, Interpreter> = {
     if (tailProto === undefined) {
       throw new Error('Unexpected end of multiaddr')
     }
-    return `${interpretNext(tailProto[0], tailProto[1] ?? '', restMa)}/ipfs/${value}`
+    return `${interpretNext(tailProto[0], tailProto[1] ?? '', restMa)}`
   },
   p2p: (value: string, restMa: StringTuple[]) => {
     const tailProto = restMa.pop()
     if (tailProto === undefined) {
       throw new Error('Unexpected end of multiaddr')
     }
-    return `${interpretNext(tailProto[0], tailProto[1] ?? '', restMa)}/p2p/${value}`
+    return `${interpretNext(tailProto[0], tailProto[1] ?? '', restMa)}`
   },
   http: (value: string, restMa: StringTuple[]) => {
     const maHasTLS = hasTLS(restMa)
@@ -196,27 +196,6 @@ const interpreters: Record<string, Interpreter> = {
     // We are reinterpreting the base as http, so we need to remove the tcp:// if it's there
     baseVal = baseVal.replace('tcp://', '')
     return `wss://${baseVal}`
-  },
-  'p2p-websocket-star': (value: string, restMa: StringTuple[]) => {
-    const tailProto = restMa.pop()
-    if (tailProto === undefined) {
-      throw new Error('Unexpected end of multiaddr')
-    }
-    return `${interpretNext(tailProto[0], tailProto[1] ?? '', restMa)}/p2p-websocket-star`
-  },
-  'p2p-webrtc-star': (value: string, restMa: StringTuple[]) => {
-    const tailProto = restMa.pop()
-    if (tailProto === undefined) {
-      throw new Error('Unexpected end of multiaddr')
-    }
-    return `${interpretNext(tailProto[0], tailProto[1] ?? '', restMa)}/p2p-webrtc-star`
-  },
-  'p2p-webrtc-direct': (value: string, restMa: StringTuple[]) => {
-    const tailProto = restMa.pop()
-    if (tailProto === undefined) {
-      throw new Error('Unexpected end of multiaddr')
-    }
-    return `${interpretNext(tailProto[0], tailProto[1] ?? '', restMa)}/p2p-webrtc-direct`
   }
 }
 

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -39,52 +39,12 @@ describe('multiaddr-to-uri', () => {
       ['/ip4/1.2.3.4/tcp/3456/wss', 'wss://1.2.3.4:3456'],
       ['/ip6/::/tcp/0/wss', 'wss://[::]:0'],
       [
-        '/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star/ipfs/QmWo6sLpfuhLnPNF1d2X6s9PXC5NvsRbC69uvHAJhZW9bk',
-        'ws://1.2.3.4:3456/p2p-webrtc-star/p2p/QmWo6sLpfuhLnPNF1d2X6s9PXC5NvsRbC69uvHAJhZW9bk'
-      ],
-      [
-        '/dnsaddr/ipfs.io/ws/p2p-webrtc-star/ipfs/QmcNwyju7SWoizsAuf6kjaaRoxe762ovsT3hz6qt3xxcsK',
-        'ws://ipfs.io/p2p-webrtc-star/p2p/QmcNwyju7SWoizsAuf6kjaaRoxe762ovsT3hz6qt3xxcsK'
-      ],
-      [
-        '/dnsaddr/ipfs.io/wss/p2p-webrtc-star/ipfs/QmcNwyju7SWoizsAuf6kjaaRoxe762ovsT3hz6qt3xxcsK',
-        'wss://ipfs.io/p2p-webrtc-star/p2p/QmcNwyju7SWoizsAuf6kjaaRoxe762ovsT3hz6qt3xxcsK'
-      ],
-      [
-        '/ip6/::/tcp/0/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo5',
-        'ws://[::]:0/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo5'
-      ],
-      [
-        '/dns4/wrtc-star.discovery.libp2p.io/tcp/443/wss/p2p-webrtc-star/ipfs/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79',
-        'wss://wrtc-star.discovery.libp2p.io:443/p2p-webrtc-star/p2p/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79'
-      ],
-      ['/ip4/1.2.3.4/tcp/3456/http/p2p-webrtc-direct', 'http://1.2.3.4:3456/p2p-webrtc-direct'],
-      ['/ip6/::/tcp/0/http/p2p-webrtc-direct', 'http://[::]:0/p2p-webrtc-direct'],
-      ['/ip4/1.2.3.4/tcp/3456/ws/p2p-websocket-star', 'ws://1.2.3.4:3456/p2p-websocket-star'],
-      ['/ip6/::/tcp/0/ws/p2p-websocket-star', 'ws://[::]:0/p2p-websocket-star'],
-      [
-        '/dnsaddr/localhost/ws/p2p-websocket-star/ipfs/QmcNwyju7SWoizsAuf6kjaaRoxe762ovsT3hz6qt3xxcsK',
-        'ws://localhost/p2p-websocket-star/p2p/QmcNwyju7SWoizsAuf6kjaaRoxe762ovsT3hz6qt3xxcsK'
-      ],
-      [
-        '/ip4/1.2.3.4/tcp/3456/ws/p2p-websocket-star/ipfs/QmcNwyju7SWoizsAuf6kjaaRoxe762ovsT3hz6qt3xxcsK',
-        'ws://1.2.3.4:3456/p2p-websocket-star/p2p/QmcNwyju7SWoizsAuf6kjaaRoxe762ovsT3hz6qt3xxcsK'
-      ],
-      [
-        '/dns4/ws-star.discovery.libp2p.io/tcp/443/wss/p2p-websocket-star/ipfs/QmP3vadpN9dqZ7j6KtmwP5Y4prg7XqdS7ixgZMWtXxBAbp',
-        'wss://ws-star.discovery.libp2p.io:443/p2p-websocket-star/p2p/QmP3vadpN9dqZ7j6KtmwP5Y4prg7XqdS7ixgZMWtXxBAbp'
-      ],
-      [
         '/ip4/127.0.0.1/tcp/20008/ws/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
-        'ws://127.0.0.1:20008/p2p/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj'
-      ],
-      [
-        '/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star/ipfs/QmcNwyju7SWoizsAuf6kjaaRoxe762ovsT3hz6qt3xxcsK',
-        'ws://1.2.3.4:3456/p2p-webrtc-star/p2p/QmcNwyju7SWoizsAuf6kjaaRoxe762ovsT3hz6qt3xxcsK'
+        'ws://127.0.0.1:20008'
       ],
       [
         '/ip4/1.2.3.4/tcp/3456/ipfs/QmcNwyju7SWoizsAuf6kjaaRoxe762ovsT3hz6qt3xxcsK',
-        'tcp://1.2.3.4:3456/p2p/QmcNwyju7SWoizsAuf6kjaaRoxe762ovsT3hz6qt3xxcsK'
+        'tcp://1.2.3.4:3456'
       ],
       [
         '/ip4/1.2.3.4/tcp/3456/http/http-path/foo%2fbar',
@@ -92,7 +52,7 @@ describe('multiaddr-to-uri', () => {
       ],
       [
         '/ip4/1.2.3.4/tcp/3456/p2p/QmcNwyju7SWoizsAuf6kjaaRoxe762ovsT3hz6qt3xxcsK',
-        'tcp://1.2.3.4:3456/p2p/QmcNwyju7SWoizsAuf6kjaaRoxe762ovsT3hz6qt3xxcsK'
+        'tcp://1.2.3.4:3456'
       ]
     ]
 


### PR DESCRIPTION
Removes support for parsing old p2p-webrtc-direct and p2p-websocket-star addresses into URLs.

Also removes support for appending `/p2p/Qmfoo`/`/ipfs/Qmfoo` to URLs automatically - we have `/http-path` now so if these tuples are required in final URLs (I don't think it is for any currently supported transports), we should use that.

BREAKING CHANGE: p2p-webrtc-direct/p2p-websocket-star support has been removed